### PR TITLE
fix: tempo-field-compactor-not-found

### DIFF
--- a/tempo/Dockerfile
+++ b/tempo/Dockerfile
@@ -1,4 +1,4 @@
-FROM grafana/tempo:latest
+FROM grafana/tempo:2.9.0
 
 COPY tempo.yml /etc/tempo/tempo.yml
 


### PR DESCRIPTION
There is a known issue with Tempo v2.10.0 where the compactor configuration block is not recognized, causing startup failures. The fix is to pin to v2.9.0 until this issue is resolved in a future release

Note: I got this fix from an error I reported on [another Grafana railway repo](https://github.com/MykalMachon/railway-grafana-stack/issues/31)